### PR TITLE
Fix typo in fstab hook docs

### DIFF
--- a/web/content/concepts/hooks/fstab/_index.md
+++ b/web/content/concepts/hooks/fstab/_index.md
@@ -15,7 +15,7 @@ To configure an ```/etc/fstab``` to be used during boot, create a ```/etc/darch/
 
 ```
 image:name=this_fstab_file
-*:that_fstab_file
+*=that_fstab_file
 ```
 
 Then place your fstab in ```/etc/darch/hooks```. For example, ```/etc/darch/hooks/this_fstab_file```.


### PR DESCRIPTION
`*:that_fstab_file` should be `*=that_fstab_file`