### PR TITLE
Add cd to recipes

### DIFF
--- a/web/content/test-drive/_index.md
+++ b/web/content/test-drive/_index.md
@@ -60,6 +60,7 @@ You can compile the images yourself. Normally, you'd want to utilize your own re
 git clone git@github.com:pauldotknopf/darch-recipes.git
 cd darch-recipes
 sudo darch images pull godarch/arch:latest
+cd recipes
 sudo darch recipes build base
 sudo darch stage upload base
 ```


### PR DESCRIPTION
You need to `cd` into recipes folder before the build, this should make it clearer.